### PR TITLE
OPEN ISSUE fix - [The rename box also becomes transparent #49]

### DIFF
--- a/themes/Default Dark.css
+++ b/themes/Default Dark.css
@@ -1,3 +1,12 @@
+/*ISSUE OPEN - [Rename box also becomes transparent #49]*/
+/* new - fix the Rename Symbol [F2] option, which was transparent */
+.monaco-editor.rename-box.preview  {
+  background: rgb(30 30 30 / 90%) !important;
+  border-radius: 0.4rem!important; 
+  padding: 0.3rem!important; 
+}
+
+
 .scroll-decoration {
   box-shadow: none !important;
 }

--- a/themes/Default Light.css
+++ b/themes/Default Light.css
@@ -1,3 +1,11 @@
+/*ISSUE OPEN - [Rename box also becomes transparent #49]*/
+/* new - fix the Rename Symbol [F2] option, which was transparent */
+.monaco-editor.rename-box.preview  {
+  background: rgb(30 30 30 / 90%) !important;
+  border-radius: 0.4rem!important; 
+  padding: 0.3rem!important; 
+}
+
 .scroll-decoration {
   box-shadow: none !important;
 }


### PR DESCRIPTION
Hi, I really liked your project and I'm already using it!
I noticed that the rename box [f2] was also transparent and saw that there was an open problem with it, so I found the solution by adding the following properties to css:

.monaco-editor.rename-box.preview {
       background: rgb (30 30 30/90%)! important; // background color
       edge radius: 0.4rem! important; // just aesthetics
       filling: 0.3 rem! important; // just aesthetics
}

Sincerely André Malveira.