### PR TITLE
Set HTMLFile for VSCode 1.70.0

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -112,7 +112,7 @@ function activate(context) {
 
 	var appDir = path.dirname(require.main.filename);
 
-	var HTMLFile = appDir + '/vs/code/electron-browser/workbench/workbench.html';
+	var HTMLFile = appDir + '/vs/code/electron-sandbox/workbench/workbench.html';
 	var JSFile = appDir + '/main.js';
 
 	var runtimeVersion = 'v6';


### PR DESCRIPTION
VSCode 1.70.0 has moved `workbench.html` to a new folder, and we'll see an error when reloading vibrancy.

![Snipaste_2022-08-05_03-13-49](https://user-images.githubusercontent.com/10987206/182935856-61033559-df3d-4168-92f4-5b657aace1a4.jpg)

This commit replaces the path to the updated one.